### PR TITLE
note that queue is not thread safe

### DIFF
--- a/doc/source/ray-core/actors/actor-utils.rst
+++ b/doc/source/ray-core/actors/actor-utils.rst
@@ -29,4 +29,4 @@ actors, you can use :ref:`ray.util.queue.Queue <ray-queue-ref>`.
 
 .. literalinclude:: ../doc_code/actor-queue.py
 
-Ray's Queue API has similar API as Python's ``asyncio.Queue`` and ``queue.Queue``.
+Ray's Queue API has similar API as Python's ``asyncio.Queue`` and ``queue.Queue``. Note that [asyncio.Queue is not thread safe](https://docs.python.org/3/library/asyncio-queue.html#asyncio.Queue), consuming the same queue from multiple actors in parallell may yield duplicate records.


### PR DESCRIPTION
Signed-off-by: David Karlsson <2795016+devdavidkarlsson@users.noreply.github.com>

## Why are these changes needed?

Using the queue to feed jobs to a set of actors yield a lot of duplicate records when read.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
